### PR TITLE
Add back-off strategy for rate-limiter

### DIFF
--- a/cassiopeia/dto/requests.py
+++ b/cassiopeia/dto/requests.py
@@ -66,11 +66,12 @@ def get(request, params={}, static=False, include_base=True):
     except urllib.error.HTTPError as e:
         # Reset rate limiter and retry on 429 (rate limit exceeded)
         if(e.code == 429 and rate_limiter):
-            try:
+            if e.headers["Retry-After"]:
                 rate_limiter.reset_in(int(e.headers["Retry-After"]) + 1)
-            except(TypeError):
-                # Retry-Ater wasn't sent
-                raise cassiopeia.type.api.exception.APIError("Server returned error {code} on call: {url}".format(code=e.code, url=url), e.code)
+            else:
+                # Retry-After headers weren't sent, back-off for 1 second and try again
+                rate_limiter.reset_in(1)
+
             return get(request, params, static)
         else:
             raise cassiopeia.type.api.exception.APIError("Server returned error {code} on call: {url}".format(code=e.code, url=url), e.code)


### PR DESCRIPTION
Hi! Thanks for creating this awesome library. This PR is a small change to how 429 response codes  are handled when the Retry-After header is missing. 

Basically it's just a simple back-off strategy as suggested in the [API Documentation](https://developer.riotgames.com/docs/rate-limiting).
> If the rate limit was enforced by the underlying service to which the request was proxied, the above headers will not be included. In that case, your code cannot use the same mechanism to handle these responses. Instead, your code would simply need to back off for a reasonable amount of time (e.g., 1 second) before trying again the same request.

Batch requests seem to be much more stable after this change.

