### PR TITLE
Dto to json options

### DIFF
--- a/cassiopeia/type/dto/common.py
+++ b/cassiopeia/type/dto/common.py
@@ -18,13 +18,16 @@ class CassiopeiaDto(object):
         for k,v in dictionary.items():
             setattr(self, k, v)
 
-    def to_json(self):
+    def to_json(self, **kwargs):
         """Gets a JSON representation of the object
         
         return    str    a JSON representation of the object
         """
         dictionary = {k: v for k,v in self.__dict__.items() if not k.startswith("_")}
-        return json.dumps(dictionary, default=lambda o: o.__dict__, sort_keys=True, indent=4)
+        default = kwargs.get('default', lambda o: o.__dict__)
+        sort_keys=kwargs.get('sort_keys', True)
+        indent=kwargs.get('indent', 4)
+        return json.dumps(dictionary, default=default, sort_keys=sort_keys, indent=indent)
 
     def __str__(self):
         return self.to_json()

--- a/cassiopeia/type/dto/common.py
+++ b/cassiopeia/type/dto/common.py
@@ -24,10 +24,10 @@ class CassiopeiaDto(object):
         return    str    a JSON representation of the object
         """
         dictionary = {k: v for k,v in self.__dict__.items() if not k.startswith("_")}
-        default = kwargs.get('default', lambda o: o.__dict__)
-        sort_keys=kwargs.get('sort_keys', True)
-        indent=kwargs.get('indent', 4)
-        return json.dumps(dictionary, default=default, sort_keys=sort_keys, indent=indent)
+        default = kwargs.pop('default', lambda o: o.__dict__)
+        sort_keys = kwargs.pop('sort_keys', True)
+        indent = kwargs.pop('indent', 4)
+        return json.dumps(dictionary, default=default, sort_keys=sort_keys, indent=indent, **kwargs)
 
     def __str__(self):
         return self.to_json()


### PR DESCRIPTION
I'm storing the json pulled with the api in files for later reuse.
The defaults passed to json.dumps, while really useful to be read, are not suited for this scenario, as you usually want one match per line.

This change allows to pass different values, while retaining the same behaviour if no argument is passed.