### PR TITLE
Fix for a HTTP Error 400: BAD_REQUEST

### DIFF
--- a/cassiopeia/dto/summonerapi.py
+++ b/cassiopeia/dto/summonerapi.py
@@ -12,7 +12,7 @@ def get_summoners_by_name(summoner_names):
     if(isinstance(summoner_names, list) and len(summoner_names) > 40):
         raise ValueError("Can only get up to 40 summoners at once.")
 
-    name_string = ",".join(str(x) for x in summoner_names) if isinstance(summoner_names, list) else str(summoner_names)
+    name_string = ",".join(str(x).replace(" ", "") for x in summoner_names) if isinstance(summoner_names, list) else str(summoner_names).replace(" ", "")
 
     # Get JSON response
     request = "{version}/summoner/by-name/{names}".format(version=cassiopeia.dto.requests.api_versions["summoner"], names=name_string)


### PR DESCRIPTION
Calling
baseriotapi.get_summoners_by_name('sir killerlord')

Generates

https://euw.api.pvp.net/api/lol/euw/v1.4/summoner/by-name/sir killerlord?api_key=

Error
Traceback (most recent call last):
  File "/Cassiopeia/cassiopeia/dto/requests.py", line 64, in get
    content = rate_limiter.call(executeRequest, url) if rate_limiter else executeRequest(url)
  File "/Cassiopeia/cassiopeia/type/api/rates.py", line 109, in call
    return method(*args)
  File "/Cassiopeia/cassiopeia/dto/requests.py", line 90, in executeRequest
    response = urllib.request.urlopen(url)
  File "/usr/lib/python3.4/urllib/request.py", line 153, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.4/urllib/request.py", line 461, in open
    response = meth(req, response)
  File "/usr/lib/python3.4/urllib/request.py", line 571, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.4/urllib/request.py", line 499, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.4/urllib/request.py", line 433, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.4/urllib/request.py", line 579, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 400: BAD_REQUEST

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tests/tier_test.py", line 55, in test_riotapibroken
    baseriotapi.get_summoners_by_name('sir killerlord')
  File "/Cassiopeia/cassiopeia/dto/summonerapi.py", line 19, in get_summoners_by_name
    response = cassiopeia.dto.requests.get(request)
  File "/Cassiopeia/cassiopeia/dto/requests.py", line 76, in get
    raise cassiopeia.type.api.exception.APIError("Server returned error {code} on call: {url}".format(code=e.code, url=url), e.code)
cassiopeia.type.api.exception.APIError: Server returned error 400 on call: https://euw.api.pvp.net/api/lol/euw/v1.4/summoner/by-name/sir killerlord?api_key=

Removing the space fixes the problem
