### PR TITLE
Add the ability to track the number of requests issued

### DIFF
--- a/cassiopeia/baseriotapi.py
+++ b/cassiopeia/baseriotapi.py
@@ -52,9 +52,19 @@ def set_region(region):
 def print_calls(on):
     """Sets whether to print calls to stdout as they are made
 
-    on    bool    the region to query against
+    on    bool    whether to print calls to stdout
     """
     cassiopeia.dto.requests.print_calls = on
+
+
+def get_requests_count(tournament=False):
+    """Returns the number of successful requests (no exceptions in the call) and total requests issued up to now
+    tournament          bool    get the request counts for the tournament requests
+
+    return              tuple   A (successful calls, total calls) tuple
+    """
+    limiter = cassiopeia.dto.requests.tournament_rate_limiter if tournament else cassiopeia.dto.requests.rate_limiter
+    return limiter.calls
 
 
 def set_rate_limit(calls_per_epoch, seconds_per_epoch):

--- a/cassiopeia/type/api/rates.py
+++ b/cassiopeia/type/api/rates.py
@@ -1,6 +1,5 @@
 import threading
 
-
 class SingleRateLimiter(object):
     """Handles a single rate limit, ensuring that calls don't exceed it"""
 
@@ -15,6 +14,8 @@ class SingleRateLimiter(object):
         self.current = 0
         self.limit = calls_per_epoch
         self.resetter = None
+        self._total_calls = 0
+        self._successful_calls = 0
 
     def call(self, method=None, *args):
         """Calls a function when the rate limit allows (first come first serve)
@@ -28,25 +29,27 @@ class SingleRateLimiter(object):
         self.semaphore.acquire()
 
         # Current tracks how many calls are currently inside the method body
-        self.lock.acquire()
-        self.current += 1
-        self.lock.release()
+        with self.lock:
+            self.current += 1
 
+        successful_call = True
         try:
-            if method:
-                return method(*args)
-            else:
-                return None
+            return method(*args) if method else None
+        except:
+            successful_call = False
+            raise
         finally:
             # If we don't have an epoch timer running, start one. Also count that we've completed a call.
-            self.lock.acquire()
-            if not self.resetter:
-                self.resetter = threading.Timer(self.seconds_per_epoch, self._reset)
-                self.resetter.daemon = True
-                self.resetter.start()
+            with self.lock:
+                if not self.resetter:
+                    self.resetter = threading.Timer(self.seconds_per_epoch, self._reset)
+                    self.resetter.daemon = True
+                    self.resetter.start()
 
-            self.current -= 1
-            self.lock.release()
+                self.current -= 1
+                self._total_calls += 1
+                if successful_call:
+                    self._successful_calls += 1
 
     def _drain(self):
         """Drains all remaining calls"""
@@ -74,18 +77,28 @@ class SingleRateLimiter(object):
 
         seconds    int    the number of seconds to wait before resetting
         """
-        self.lock.acquire()
+        with self.lock:
 
-        if self.resetter:
-            self.resetter.cancel()
+            if self.resetter:
+                self.resetter.cancel()
 
-        self._drain()
-        self.resetter = threading.Timer(seconds, self._reset)
-        self.resetter.daemon = True
-        self.resetter.start()
+            self._drain()
+            self.resetter = threading.Timer(seconds, self._reset)
+            self.resetter.daemon = True
+            self.resetter.start()
 
-        self.lock.release()
+    def _decrease_successful_calls(self):
+        with self.lock:
+            self._successful_calls -= 1
 
+    @property
+    def calls(self):
+        """Returns the number of successful calls (no exceptions in the call) and total calls served by this limiter
+
+        return    tuple   A (successful calls, total calls) tuple
+        """
+        with self.lock:
+            return (self._successful_calls, self._total_calls)
 
 class MultiRateLimiter(object):
     """Handles a multiple rate limits simultaneously, ensuring that calls don't exceed them"""
@@ -109,14 +122,19 @@ class MultiRateLimiter(object):
         """
         self.wait()
 
+        successful_call = True
         try:
-            if method:
-                return method(*args)
-            else:
-                return None
+            return method(*args) if method else None
+        except:
+            successful_call = False
+            raise
         finally:
             for limit in self.limits:
+                # call with method=None always updates the successful calls
                 limit.call()
+                if not successful_call:
+                    limit._decrease_successful_calls()
+
 
     def wait(self):
         """Waits until a call becomes available"""
@@ -130,3 +148,15 @@ class MultiRateLimiter(object):
         """
         for limit in self.limits:
             limit.reset_in(seconds)
+
+    @property
+    def calls(self):
+        """Returns the number of successful calls (no exceptions in the call) and total calls served by this limiter
+
+        return    tuple   A (successful calls, total calls) tuple
+        """
+        try:
+            return self.limits[0].calls
+        except IndexError:
+            # Disable the counting if no limits are enforced
+            return 0

--- a/test/integration/dto/rates.py
+++ b/test/integration/dto/rates.py
@@ -1,0 +1,20 @@
+from cassiopeia import baseriotapi
+from .. import int_test_handler
+
+
+def test_all():
+    print("dto/requests tests...")
+    test_tracking_on_valid_request()
+
+
+def test_tracking_on_valid_request():
+    """Checks that the request tracking works on requests with expected return code of 200"""
+    int_test_handler.test_result(baseriotapi.get_requests_count() == (0,0))
+    int_test_handler.test_result(baseriotapi.get_match(int_test_handler.match_id))
+    int_test_handler.test_result(baseriotapi.get_requests_count() == (1,1))
+
+def test_tracking_on_404_request():
+    """Checks that the request tracking works on requests which raise exceptions"""
+    int_test_handler.test_result(baseriotapi.get_requests_count() == (0,0))
+    int_test_handler.test_result(baseriotapi.get_champion(int_test_handler.non_existent_champion_id))
+    int_test_handler.test_result(baseriotapi.get_requests_count() == (0,1))

--- a/test/integration/int_test_handler.py
+++ b/test/integration/int_test_handler.py
@@ -12,6 +12,7 @@ if RIOT_API_KEY:
     riotapi.print_calls(True)
     riotapi.set_load_policy(LoadPolicy.lazy)
 
+non_existent_champion_id = 1000
 champion_id = 35
 champion_name = "Thresh"
 mastery_id = 6361


### PR DESCRIPTION
This PR adds the ability (disabled by default) of tracking the requests which are made.

This allows users of the library to track of the usage of their limit, allowing to better investigate performances and efficiency of their code.

I find this fundamental as I try a different architectural approach for my library, to be able to compare if I'm effectively improving the performances or not.

This would make debugging issues like #16 a lot easier as well.

Accept one PR, get one fix for free: fixed a typo in the documentation